### PR TITLE
Add .gitignore to the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+*.egg-info
+*__pycache__


### PR DESCRIPTION
Installing or testing the library generates many files that we don't want to add under VCS. This PR excludes them from git via `.gitignore`